### PR TITLE
Aggregate the JS and JVM projects to simplify builds.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,15 @@
 name := "Foo root project"
 
-lazy val root = project.in(file(".")).aggregate()
+lazy val root = project.in(file(".")).aggregate(fooJS, fooJVM).settings(
+  publish := {},
+  publishLocal := {}
+)
 
 lazy val fooSharedSettings = Seq(
     name := "foo",
     version := "0.1-SNAPSHOT",
     unmanagedSourceDirectories in Compile +=
-      (baseDirectory in root).value / "foo-shared" / "src" / "main" / "scala"
+      baseDirectory.value / ".." / "foo-shared" / "src" / "main" / "scala"
 )
 
 lazy val fooJS = project.in(file("foo-js"))


### PR DESCRIPTION
Currently, commands such as `compile` and `publish` do
not propagate to the JS and JVM projects, requiring
separate `fooJS/compile` and 'fooJVM/compile` etc commands.
By making the top-level project aggregate the JS and JVM
projects, such commands now automatically propagate to
the subproject.

By naming the root and subprojects the same, it also
avoids publishing an empty jar (foo-root-project) when
`publish` is invoked at the root project. Instead,  now
it correctly delivers `foo` and `foo_sjs` jars.
