### PR TITLE
Restructured the SBT configuration to play better together with IntelliJ IDEA

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,29 @@
 name := "Foo root project"
 
-lazy val root = project.in(file(".")).aggregate(fooJS, fooJVM).settings(
-  publish := {},
-  publishLocal := {}
-)
+lazy val root = project.in(file("."))
+  .aggregate(fooJS, fooJVM)
+  .settings(
+    publish := {},
+    publishLocal := {}
+  )
+
+// Project containing source code shared between the JS and JVM projects.
+// This project should never be compiled or packages but is simply an IntelliJ IDEA
+// friendly alternative to a shared code directory. Projects depending on this
+// projects source code should declare a dependency as 'Provided' AND append
+// this projects source directory manually to 'unmanagedSourceDirectories'.
+lazy val fooShared = project.in(file("foo-shared"))
 
 lazy val fooSharedSettings = Seq(
-    name := "foo",
-    version := "0.1-SNAPSHOT",
-    unmanagedSourceDirectories in Compile +=
-      baseDirectory.value / ".." / "foo-shared" / "src" / "main" / "scala"
+  name := "foo",
+  version := "0.1-SNAPSHOT",
+  // NOTE: The following line will generate a warning in IntelliJ IDEA, which can be ignored:
+  // "The following source roots are outside the corresponding base directories"
+  unmanagedSourceDirectories in Compile += (scalaSource in (fooShared, Compile)).value
 )
 
 lazy val fooJS = project.in(file("foo-js"))
+  .dependsOn(fooShared % Provided)
   .settings(scalaJSSettings: _*)
   .settings(fooSharedSettings: _*)
   .settings(
@@ -20,6 +31,7 @@ lazy val fooJS = project.in(file("foo-js"))
   )
 
 lazy val fooJVM = project.in(file("foo-jvm"))
+  .dependsOn(fooShared % Provided)
   .settings(fooSharedSettings: _*)
   .settings(
     // Add JVM-specific settings here


### PR DESCRIPTION
The shared source code directory as been replaced by a shared SBT project. The two projects for JS and JVM is now depending on the shared project, but as 'Provided'. They are still adding the shared source directory to their 'unmanagedSourceDirectories' list. Including this directory, that is outside the projects base directory, will not take effect in IntelliJ and generate a warning. But IntelliJ will still see the right dependencies to the shared code due to the project dependencies.

Tested in Idea 14.0 on Linux. I am not using the gen-idea SBT plugin.